### PR TITLE
air/i-want-to-add-analysis-plot-on-glow_record-page-so-please-planni-c831f24e-d

### DIFF
--- a/lib/record/record.dart
+++ b/lib/record/record.dart
@@ -6,6 +6,7 @@ import 'package:wo_read/record/models/lunar_age.dart';
 import 'package:wo_read/record/models/record_item.dart';
 import 'package:wo_read/record/screens/modify_record.dart';
 import 'package:wo_read/record/service/record_service.dart';
+import 'package:wo_read/record/screens/record_analysis_section.dart';
 import 'package:wo_read/record/use_cases/lunar_age_use_case.dart';
 
 class RecordPage extends StatefulWidget {
@@ -63,15 +64,16 @@ Widget _recordsSet(List<RecordItem> records, Function() backAction) {
 
   return SingleChildScrollView(
     child: Column(
-      children: lunarAgeGroup.entries
-          .map(
-            (entry) => _lunarAgeRecords(
-              lunarAge: entry.key,
-              records: entry.value,
-              backAction: backAction,
-            ),
-          )
-          .toList(),
+      children: [
+        RecordAnalysisSection(records: records),
+        ...lunarAgeGroup.entries.map(
+          (entry) => _lunarAgeRecords(
+            lunarAge: entry.key,
+            records: entry.value,
+            backAction: backAction,
+          ),
+        ),
+      ],
     ),
   );
 }

--- a/lib/record/screens/record_analysis_section.dart
+++ b/lib/record/screens/record_analysis_section.dart
@@ -46,7 +46,7 @@ class _FeelingPieChart extends StatelessWidget {
     final counts = countByFeelingType(records);
 
     final sections = FeelingType.values
-        .where((t) => (counts[t] ?? 0) > 0)
+        .where((t) => t != FeelingType.none && (counts[t] ?? 0) > 0)
         .map((t) {
           final count = counts[t]!;
           return PieChartSectionData(
@@ -98,7 +98,7 @@ class _DenverBarChart extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final counts = countByDenverType(records);
-    final types = DenverType.values;
+    final types = DenverType.values.where((t) => t != DenverType.none).toList();
     final maxCount =
         types.map((t) => counts[t] ?? 0).reduce((a, b) => a > b ? a : b);
     const _niceSteps = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000];

--- a/lib/record/screens/record_analysis_section.dart
+++ b/lib/record/screens/record_analysis_section.dart
@@ -1,0 +1,173 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:wo_read/record/models/record_item.dart';
+import 'package:wo_read/record/use_cases/record_analysis_use_case.dart';
+
+class RecordAnalysisSection extends StatelessWidget {
+  final List<RecordItem> records;
+
+  const RecordAnalysisSection({super.key, required this.records});
+
+  @override
+  Widget build(BuildContext context) {
+    if (records.isEmpty) {
+      return const Card(
+        child: Padding(
+          padding: EdgeInsets.all(16),
+          child: Center(child: Text('データなし')),
+        ),
+      );
+    }
+
+    return Column(
+      children: [
+        _FeelingPieChart(records: records),
+        _DenverBarChart(records: records),
+      ],
+    );
+  }
+}
+
+class _FeelingPieChart extends StatelessWidget {
+  final List<RecordItem> records;
+
+  const _FeelingPieChart({required this.records});
+
+  static const Map<FeelingType, Color> _colors = {
+    FeelingType.none: Colors.grey,
+    FeelingType.happiness: Colors.amber,
+    FeelingType.anger: Colors.red,
+    FeelingType.sorrow: Colors.blue,
+    FeelingType.pleasure: Colors.green,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final counts = countByFeelingType(records);
+
+    final sections = FeelingType.values
+        .where((t) => (counts[t] ?? 0) > 0)
+        .map((t) {
+          final count = counts[t]!;
+          return PieChartSectionData(
+            color: _colors[t] ?? Colors.grey,
+            value: count.toDouble(),
+            title: '${feelingToJp[t]}\n$count',
+            radius: 80,
+            titleStyle: const TextStyle(
+              fontSize: 11,
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
+          );
+        })
+        .toList();
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('気持ち分布', style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            SizedBox(
+              height: 200,
+              child: PieChart(PieChartData(sections: sections)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DenverBarChart extends StatelessWidget {
+  final List<RecordItem> records;
+
+  const _DenverBarChart({required this.records});
+
+  static const Map<DenverType, Color> _colors = {
+    DenverType.none: Colors.grey,
+    DenverType.personalSocial: Colors.purple,
+    DenverType.fineMotorAdaptive: Colors.orange,
+    DenverType.language: Colors.teal,
+    DenverType.grossMotor: Colors.indigo,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final counts = countByDenverType(records);
+    final types = DenverType.values;
+    final maxCount =
+        types.map((t) => counts[t] ?? 0).reduce((a, b) => a > b ? a : b);
+
+    final barGroups = types.asMap().entries
+        .map((entry) => BarChartGroupData(
+              x: entry.key,
+              barRods: [
+                BarChartRodData(
+                  toY: (counts[entry.value] ?? 0).toDouble(),
+                  color: _colors[entry.value] ?? Colors.grey,
+                ),
+              ],
+            ))
+        .toList();
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('発達分布', style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            SizedBox(
+              height: 200,
+              child: BarChart(
+                BarChartData(
+                  maxY: (maxCount > 0 ? maxCount + 1 : 5).toDouble(),
+                  barGroups: barGroups,
+                  titlesData: FlTitlesData(
+                    bottomTitles: AxisTitles(
+                      sideTitles: SideTitles(
+                        showTitles: true,
+                        reservedSize: 32,
+                        getTitlesWidget: (value, meta) {
+                          final index = value.toInt();
+                          if (index < 0 || index >= types.length) {
+                            return const SizedBox();
+                          }
+                          return Padding(
+                            padding: const EdgeInsets.only(top: 4),
+                            child: Text(
+                              denverToJp[types[index]] ?? '',
+                              style: const TextStyle(fontSize: 9),
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                    leftTitles: AxisTitles(
+                      sideTitles: SideTitles(
+                        showTitles: true,
+                        reservedSize: 28,
+                        interval: 1,
+                      ),
+                    ),
+                    topTitles: AxisTitles(
+                      sideTitles: SideTitles(showTitles: false),
+                    ),
+                    rightTitles: AxisTitles(
+                      sideTitles: SideTitles(showTitles: false),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/record/screens/record_analysis_section.dart
+++ b/lib/record/screens/record_analysis_section.dart
@@ -101,6 +101,10 @@ class _DenverBarChart extends StatelessWidget {
     final types = DenverType.values;
     final maxCount =
         types.map((t) => counts[t] ?? 0).reduce((a, b) => a > b ? a : b);
+    const _niceSteps = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000];
+    final leftInterval = _niceSteps
+        .firstWhere((s) => s >= maxCount / 5, orElse: () => _niceSteps.last)
+        .toDouble();
 
     final barGroups = types.asMap().entries
         .map((entry) => BarChartGroupData(
@@ -152,7 +156,7 @@ class _DenverBarChart extends StatelessWidget {
                       sideTitles: SideTitles(
                         showTitles: true,
                         reservedSize: 28,
-                        interval: 1,
+                        interval: leftInterval,
                       ),
                     ),
                     topTitles: AxisTitles(

--- a/lib/record/use_cases/record_analysis_use_case.dart
+++ b/lib/record/use_cases/record_analysis_use_case.dart
@@ -1,0 +1,17 @@
+import 'package:wo_read/record/models/record_item.dart';
+
+Map<FeelingType, int> countByFeelingType(List<RecordItem> records) {
+  final counts = {for (final t in FeelingType.values) t: 0};
+  for (final r in records) {
+    counts[r.feeling] = counts[r.feeling]! + 1;
+  }
+  return counts;
+}
+
+Map<DenverType, int> countByDenverType(List<RecordItem> records) {
+  final counts = {for (final t in DenverType.values) t: 0};
+  for (final r in records) {
+    counts[r.denver] = counts[r.denver]! + 1;
+  }
+  return counts;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -441,6 +441,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: "74959b99b92b9eebeed1a4049426fd67c4abc3c5a0f4d12e2877097d6a11ae08"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.69.2"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   image: ^4.8.0
   path_provider: ^2.1.5
   cached_network_image: ^3.4.1
+  fl_chart: ^0.69.0
 
 
 dev_dependencies:


### PR DESCRIPTION
タイトル: feat: add feeling and Denver analysis charts to RecordPage

本文:

Summary
* fl_chart を追加し、RecordPage の上部に気持ち分布（円グラフ）と発達分布（棒グラフ）の分析セクションを追加
* 縦軸ラベルは 2・5・10 などキリの良い間隔で自動調整
* 気持ち・発達ともに「無し」はグラフから除外